### PR TITLE
use mathjax extension in order to support latex by default

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ version = ".".join(release.split('.')[:2])  # shorter X.Y version
 
 # .nojekyll prevents GitHub from hiding the `_static` dir
 #sys.path += ['exts']
-extensions = ['sphinxcontrib.rawfiles']
+extensions = ['sphinxcontrib.rawfiles, sphinx.ext.mathjax']
 rawfiles = ['.nojekyll']
 
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']


### PR DESCRIPTION
It looks like simply adding the mathjax extension to the `extensions` list is enough, see:
![Screen Shot 2019-08-27 at 7 36 38 PM](https://user-images.githubusercontent.com/13077051/63812836-07d49280-c902-11e9-843c-1e265f054979.png)

PS: I **love** the fact that, with the Amunra theme, Jupyter notebook are centralized in the browser.

Edit: closes #1 