### PR TITLE
Allow @mirca to override the theme css

### DIFF
--- a/amunra_sphinx_theme/layout.html
+++ b/amunra_sphinx_theme/layout.html
@@ -1,13 +1,12 @@
 {% extends "basic/layout.html" %}
+{% set css_files = ["https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css",
+                    "_static/css/amunra.css"]
+                    + css_files %}
 
 {%- block extrahead %}
-    <!-- Load Bootstrap CSS and Javascript (Javascript is needed for the navbar toggle) -->
+    <!-- Load Bootstrap viewport and Javascript (Javascript is needed for the navbar toggle) -->
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
-
-    <!-- Load the theme's CSS. -->
-    <link rel="stylesheet" href="{{ pathto('_static/css/amunra.css', 1) }}" type="text/css" />
 
     {% if theme_analytics_id %}
       <!-- Google Analytics -->

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,10 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 html_static_path = ['_static']
 
+# If you want to override the theme style, create a file named
+# "_static/custom.css" and uncomment the line below to activate:
+# html_css_files = ['custom.css']
+
 html_theme = 'amunra_sphinx_theme'
 
 html_theme_options = {


### PR DESCRIPTION
This PR enables [power users](https://github.com/mirca) to override the theme CSS via the `html_css_files` option in `conf.py`.

For example use, see https://github.com/barentsen/amunra-sphinx-theme/issues/7